### PR TITLE
Suggestions for corrections to CoTeDe glue script in AutoQC

### DIFF
--- a/cotede_qc/cotede_test.py
+++ b/cotede_qc/cotede_test.py
@@ -57,22 +57,25 @@ def get_qc(p, config, test):
                 elif test != config:
                     # Load from TEMP,
                     try:
-                        cfg = {'variables': {'sea_water_temperature': {test: cfg['variables']['sea_water_temperature'][test]}}}
+                        cfg = {'sea_water_temperature': {test: cfg['variables']['sea_water_temperature'][test]}}
                     # otherwise load it from main.
                     except:
                         # The dummy configuration ensures that the results from
                         # 'main' is copied into the results for var.
-                        cfg = {'common': {test: cfg['common'][test]}, var: {'dummy': None}}
+                        cfg = {'common': {test: cfg['common'][test]}}
             except:
                 with open('cotede_qc/qc_cfg/' + config + '.json') as f:
                     cfg = json.load(f)
 
         pqc = ProfileQC(inputs, cfg=cfg)
 
-        cotede_results = [p.uid(), config, pqc.flags[var].keys(), pqc]
-
     # Get the QC results, which use the IOC conventions.
-    qc_returned = cotede_results[3].flags[var][test]
+    try:
+        qc_returned = pqc.flags[var][test]
+    except:
+        # common category tests just return one QC code for the whole profile,
+        # but AutoQC expects a per level report
+        qc_returned = pqc.flags['common'][test].repeat(p.n_levels())
 
     # It looks like CoTeDe never returns a QC decision
     # of 2. If it ever does, we need to decide whether 


### PR DESCRIPTION
Hi @castelao - here's my best guess at corrections to your AutoQC PR https://github.com/IQuOD/AutoQC/pull/259, when you have time to look at this (no rush at all). To summarize:

 - Remove the double variables key I pointed out in that PR
 - Catch cases where we're using the `common` suite of tests, and extract configs from `cfg['common'][testname]` instead of relying on the awkward `dummy` kludge currently in AutoQC. Also makes the assumption that the `common` class of CoTeDe tests all return a single QC decision for the whole profile, instead of per level flags.

These are not necessarily the best way to solve these problems, but I present them like this as the clearest way to show what I had to do to amend `cotede_qc/cotede_test.py`. If you see a cleaner solution, feel free to close this and amend as you see fit.